### PR TITLE
Fix custom list stylesheet references

### DIFF
--- a/Editor/Utils/CustomGenericListDrawer.cs
+++ b/Editor/Utils/CustomGenericListDrawer.cs
@@ -196,7 +196,7 @@ namespace Jungle.Editor
             }
             
             // Apply stylesheet
-            AddOctoputsStyleSheet(listContainer);
+            AddJungleStyleSheet(listContainer);
 
             // Initial build
             RebuildList();
@@ -592,10 +592,10 @@ namespace Jungle.Editor
             }
         }
 
-        private static void AddOctoputsStyleSheet(VisualElement element)
+        private static void AddJungleStyleSheet(VisualElement element)
         {
             // Check if the list style sheet is already loaded
-            var listStyleSheet = Resources.Load<StyleSheet>("OctoputsListStyles");
+            var listStyleSheet = Resources.Load<StyleSheet>("JungleListStyles");
             if (listStyleSheet != null)
             {
                 // Only add if not already present
@@ -606,7 +606,7 @@ namespace Jungle.Editor
             }
             else
             {
-                Debug.LogWarning("Could not load OctoputsListStyles.uss from Resources folder");
+                Debug.LogWarning("Could not load JungleListStyles.uss from Resources folder");
             }
         }
     }

--- a/Editor/Utils/Resources/CustomGenericListContainer.uxml
+++ b/Editor/Utils/Resources/CustomGenericListContainer.uxml
@@ -1,6 +1,6 @@
 ﻿<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsEditorStyles.uss" />
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsListStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleEditorStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleListStyles.uss" />
     <ui:VisualElement class="octoputs-section octoputs-custom-list-container">
         <ui:VisualElement name="list-header" class="octoputs-actions-inline-container">
             <ui:Label name="list-title" text="List" class="octoputs-list-section-header" />

--- a/Editor/Utils/Resources/CustomGenericListItem.uxml
+++ b/Editor/Utils/Resources/CustomGenericListItem.uxml
@@ -1,6 +1,6 @@
 ﻿<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsEditorStyles.uss" />
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsListStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleEditorStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleListStyles.uss" />
     <ui:VisualElement class="octoputs-custom-list-item">
         <ui:VisualElement name="item-header" class="octoputs-actions-inline-container">
             <ui:Label name="item-title" text="Class Name" class="octoputs-custom-list-item-title" />

--- a/Editor/Utils/Resources/CustomGenericListNullItem.uxml
+++ b/Editor/Utils/Resources/CustomGenericListNullItem.uxml
@@ -1,6 +1,6 @@
 ﻿<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsEditorStyles.uss" />
-    <Style src="project://database/Assets/Plugins/Octoputs%20-%203D%20Drag%20And%20Drop/Editor/Resources/OctoputsListStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleEditorStyles.uss" />
+    <Style src="project://database/Packages/jungle.core/Editor/Resources/JungleListStyles.uss" />
     <ui:VisualElement class="octoputs-custom-list-null-action-container">
         <ui:VisualElement class="octoputs-actions-inline-container">
             <ui:Label name="null-action-label" text="Null Action" class="octoputs-custom-list-null-action-label" />


### PR DESCRIPTION
## Summary
- update the custom generic list drawer to load the Jungle list stylesheet from Resources
- point the custom list UXML templates at the Jungle package USS assets instead of the old Octoputs paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d17f9a03d88320a400ab12fd7bb622