### PR TITLE
Add Jungle class selection attribute for contextual component buttons

### DIFF
--- a/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
+++ b/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
@@ -1,0 +1,45 @@
+#if UNITY_EDITOR
+using Jungle.Attributes;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Jungle.Editor
+{
+    [CustomPropertyDrawer(typeof(JungleClassSelectionAttribute))]
+    public class JungleClassSelectionAttributeDrawer : PropertyDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var classSelectionAttribute = (JungleClassSelectionAttribute)attribute;
+            var baseType = classSelectionAttribute.BaseType ?? fieldInfo?.FieldType;
+
+            var propertyField = new PropertyField(property);
+
+            if (baseType != null && typeof(Component).IsAssignableFrom(baseType))
+            {
+                var isInitialized = false;
+                propertyField.RegisterCallback<AttachToPanelEvent>(_ =>
+                {
+                    if (isInitialized)
+                    {
+                        return;
+                    }
+
+                    isInitialized = true;
+                    EditorUtils.SetupFieldWithClassSelectionButton(propertyField, baseType, property);
+                });
+            }
+            else
+            {
+                Debug.LogWarning(
+                    $"JungleClassSelectionAttribute requires a Component type but '{baseType?.Name ?? fieldInfo?.FieldType.Name}' does not inherit from Component."
+                );
+            }
+
+            return propertyField;
+        }
+    }
+}
+#endif

--- a/Scripts/Attributes/JungleClassSelectionAttribute.cs
+++ b/Scripts/Attributes/JungleClassSelectionAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Attributes
+{
+    /// <summary>
+    /// Adds a contextual class selection button to component reference fields in the inspector.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class JungleClassSelectionAttribute : PropertyAttribute
+    {
+        /// <summary>
+        /// Base type used to populate the class selection menu. If null the field type will be used.
+        /// </summary>
+        public Type BaseType { get; }
+
+        /// <summary>
+        /// Creates a new attribute instance using the specified base type.
+        /// </summary>
+        /// <param name="baseType">The base component type that will populate the selection menu.</param>
+        public JungleClassSelectionAttribute(Type baseType = null)
+        {
+            BaseType = baseType;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a JungleClassSelectionAttribute for marking component reference fields that need a contextual class picker
- implement a matching editor drawer that injects the class selection button via EditorUtils

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4066d203c832084b782caf2420e69