### PR TITLE
Add UXML-based editors for condition types

### DIFF
--- a/Editor/Conditions/CombinatoryConditionDrawer.cs
+++ b/Editor/Conditions/CombinatoryConditionDrawer.cs
@@ -1,0 +1,38 @@
+#if UNITY_EDITOR
+using Jungle.Conditions;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Jungle.Editor.Conditions
+{
+    [CustomPropertyDrawer(typeof(CombinatoryCondition))]
+    public class CombinatoryConditionDrawer : ConditionDrawerBase
+    {
+        private const string TemplatePath = "CombinatoryConditionDrawer";
+
+        protected override string ContentTemplatePath => TemplatePath;
+
+        protected override void InitializeContent(VisualElement contentRoot, SerializedProperty property)
+        {
+            if (contentRoot == null)
+            {
+                Debug.LogError("Missing content root for CombinatoryCondition drawer");
+                return;
+            }
+
+            var logicalOperatorField = contentRoot.Q<PropertyField>("logical-operator-field");
+            var logicalOperatorProperty = property.FindPropertyRelative("logicalOperator");
+
+            if (logicalOperatorProperty == null)
+            {
+                Debug.LogError("logicalOperator property not found on CombinatoryCondition");
+                return;
+            }
+
+            logicalOperatorField?.BindProperty(logicalOperatorProperty);
+        }
+    }
+}
+#endif

--- a/Editor/Conditions/ConditionDrawer.cs
+++ b/Editor/Conditions/ConditionDrawer.cs
@@ -1,0 +1,70 @@
+#if UNITY_EDITOR
+using System.Reflection;
+using Jungle.Attributes;
+using Jungle.Conditions;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Jungle.Editor.Conditions
+{
+    [CustomPropertyDrawer(typeof(Condition), true)]
+    public class ConditionDrawer : ConditionDrawerBase
+    {
+        protected override string ContentTemplatePath => null;
+
+        protected override void InitializeContent(VisualElement contentRoot, SerializedProperty property)
+        {
+            if (contentRoot == null)
+            {
+                Debug.LogError("Missing content root for Condition drawer");
+                return;
+            }
+
+            var conditionInstance = GetConditionInstance(property);
+            var conditionType = conditionInstance?.GetType() ?? fieldInfo?.FieldType;
+            if (conditionType == null)
+            {
+                return;
+            }
+
+            var fields = conditionType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            foreach (var field in fields)
+            {
+                if (field.Name == "negateCondition")
+                {
+                    continue;
+                }
+
+                var hasSerializeFieldAttribute = field.GetCustomAttribute<SerializeField>() != null;
+                var hasSerializeReferenceAttribute = field.GetCustomAttribute<SerializeReference>() != null;
+                var isSerializedField = field.IsPublic || hasSerializeFieldAttribute || hasSerializeReferenceAttribute;
+
+                if (!isSerializedField)
+                {
+                    continue;
+                }
+
+                if (field.GetCustomAttribute<JungleListAttribute>() != null)
+                {
+                    continue;
+                }
+
+                var fieldProperty = property.FindPropertyRelative(field.Name);
+                if (fieldProperty == null)
+                {
+                    continue;
+                }
+
+                var propertyField = new PropertyField(fieldProperty.Copy());
+                propertyField.AddToClassList("jungle-marginfield");
+                propertyField.BindProperty(fieldProperty);
+                contentRoot.Add(propertyField);
+            }
+        }
+
+    }
+}
+#endif

--- a/Editor/Conditions/ConditionDrawerBase.cs
+++ b/Editor/Conditions/ConditionDrawerBase.cs
@@ -1,0 +1,256 @@
+#if UNITY_EDITOR
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Jungle.Attributes;
+using Jungle.Conditions;
+using Jungle.Editor;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Jungle.Editor.Conditions
+{
+    internal abstract class ConditionDrawerBase : PropertyDrawer
+    {
+        private const string BaseTemplatePath = "ConditionDrawer";
+        private const string EditorStyleSheetPath = "JungleEditorStyles";
+        private const string ListStyleSheetPath = "JungleListStyles";
+
+        protected abstract string ContentTemplatePath { get; }
+
+        protected virtual void InitializeContent(VisualElement contentRoot, SerializedProperty property)
+        {
+        }
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var baseTemplate = Resources.Load<VisualTreeAsset>(BaseTemplatePath);
+            if (baseTemplate == null)
+            {
+                Debug.LogError($"Could not load {BaseTemplatePath}.uxml from Resources folder");
+                return new Label("Missing Condition Template");
+            }
+
+            var root = baseTemplate.CloneTree();
+
+            AddStyleSheet(root, EditorStyleSheetPath);
+            AddStyleSheet(root, ListStyleSheetPath);
+
+            var contentContainer = root.Q<VisualElement>("condition-content") ?? root;
+            VisualElement contentRoot = contentContainer;
+
+            if (!string.IsNullOrEmpty(ContentTemplatePath))
+            {
+                var contentTemplate = Resources.Load<VisualTreeAsset>(ContentTemplatePath);
+                if (contentTemplate == null)
+                {
+                    Debug.LogError($"Could not load {ContentTemplatePath}.uxml from Resources folder");
+                }
+                else
+                {
+                    contentRoot = contentTemplate.CloneTree();
+                    contentContainer.Add(contentRoot);
+                }
+            }
+
+            SetupConditionMetadata(root, property);
+
+            InitializeContent(contentRoot, property);
+
+            root.BindProperty(property);
+
+            ProcessJungleListAttributes(root, property);
+
+            return root;
+        }
+
+        private void SetupConditionMetadata(VisualElement root, SerializedProperty property)
+        {
+            var conditionInstance = GetConditionInstance(property);
+            var conditionType = conditionInstance?.GetType() ?? fieldInfo?.FieldType;
+
+            var titleLabel = root.Q<Label>("condition-title");
+            if (titleLabel != null && conditionType != null)
+            {
+                titleLabel.text = EditorUtils.FormatTypeName(conditionType);
+            }
+
+            var infoContainer = root.Q<VisualElement>("condition-info");
+            var descriptionLabel = root.Q<Label>("condition-description");
+
+            if (conditionType != null)
+            {
+                var infoAttribute = conditionType.GetCustomAttribute<JungleInfoAttribute>();
+                if (!string.IsNullOrEmpty(infoAttribute?.Description))
+                {
+                    if (descriptionLabel != null)
+                    {
+                        descriptionLabel.text = infoAttribute.Description;
+                    }
+                    if (infoContainer != null)
+                    {
+                        infoContainer.style.display = DisplayStyle.Flex;
+                    }
+                    return;
+                }
+            }
+
+            if (infoContainer != null)
+            {
+                infoContainer.style.display = DisplayStyle.None;
+            }
+        }
+
+        protected object GetConditionInstance(SerializedProperty property)
+        {
+            if (property == null)
+            {
+                return null;
+            }
+
+            if (property.propertyType == SerializedPropertyType.ManagedReference)
+            {
+                return property.managedReferenceValue;
+            }
+
+            if (fieldInfo != null && property.serializedObject?.targetObject != null)
+            {
+                try
+                {
+                    return fieldInfo.GetValue(property.serializedObject.targetObject);
+                }
+                catch (ArgumentException)
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private void ProcessJungleListAttributes(VisualElement root, SerializedProperty property)
+        {
+            if (root == null || property == null)
+            {
+                return;
+            }
+
+            var conditionInstance = GetConditionInstance(property);
+            var conditionType = conditionInstance?.GetType() ?? fieldInfo?.FieldType;
+            if (conditionType == null)
+            {
+                return;
+            }
+
+            var fields = conditionType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            foreach (var field in fields)
+            {
+                var listAttribute = field.GetCustomAttribute<JungleListAttribute>();
+                if (listAttribute == null)
+                {
+                    continue;
+                }
+
+                var listProperty = property.FindPropertyRelative(field.Name);
+                if (listProperty == null)
+                {
+                    continue;
+                }
+
+                var containerName = !string.IsNullOrEmpty(listAttribute.UIElementName)
+                    ? listAttribute.UIElementName
+                    : GenerateUIElementName(field.Name);
+
+                var containerElement = root.Q<VisualElement>(containerName);
+                if (containerElement == null)
+                {
+                    Debug.LogWarning(
+                        $"Could not find UI element '{containerName}' for field '{field.Name}' in {conditionType.Name}");
+                    continue;
+                }
+
+                var elementType = GetListElementType(field.FieldType);
+                if (elementType == null)
+                {
+                    Debug.LogWarning($"Could not determine list element type for field '{field.Name}'");
+                    continue;
+                }
+
+                CustomGenericListDrawer.CreateCustomList(
+                    elementType,
+                    containerElement,
+                    listProperty,
+                    property.serializedObject,
+                    listAttribute.ListTitle,
+                    listAttribute.EmptyMessage);
+            }
+        }
+
+        private static void AddStyleSheet(VisualElement element, string styleSheetPath)
+        {
+            if (element == null || string.IsNullOrEmpty(styleSheetPath))
+            {
+                return;
+            }
+
+            var styleSheet = Resources.Load<StyleSheet>(styleSheetPath);
+            if (styleSheet == null)
+            {
+                Debug.LogWarning($"Could not load {styleSheetPath}.uss from Resources folder");
+                return;
+            }
+
+            if (!element.styleSheets.Contains(styleSheet))
+            {
+                element.styleSheets.Add(styleSheet);
+            }
+        }
+
+        private static Type GetListElementType(Type fieldType)
+        {
+            if (fieldType == null)
+            {
+                return null;
+            }
+
+            if (fieldType.IsArray)
+            {
+                return fieldType.GetElementType();
+            }
+
+            if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.List<>))
+            {
+                return fieldType.GetGenericArguments().FirstOrDefault();
+            }
+
+            return null;
+        }
+
+        private static string GenerateUIElementName(string fieldName)
+        {
+            if (string.IsNullOrEmpty(fieldName))
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(fieldName.Length * 2);
+            for (int i = 0; i < fieldName.Length; i++)
+            {
+                var character = fieldName[i];
+                if (i > 0 && char.IsUpper(character))
+                {
+                    builder.Append('-');
+                }
+                builder.Append(char.ToLowerInvariant(character));
+            }
+
+            builder.Append("-content");
+            return builder.ToString();
+        }
+    }
+}
+#endif

--- a/Editor/Conditions/ExternalConditionDrawer.cs
+++ b/Editor/Conditions/ExternalConditionDrawer.cs
@@ -1,91 +1,79 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
+using Jungle.Conditions;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
-using Jungle.Conditions;
 
-namespace Octoputs.Editor.Conditions
+namespace Jungle.Editor.Conditions
 {
     [CustomPropertyDrawer(typeof(ExternalCondition))]
-    public class ExternalConditionDrawer : PropertyDrawer
+    public class ExternalConditionDrawer : ConditionDrawerBase
     {
-        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        private const string TemplatePath = "ExternalConditionDrawer";
+
+        protected override string ContentTemplatePath => TemplatePath;
+
+        protected override void InitializeContent(VisualElement contentRoot, SerializedProperty property)
         {
-            // Load the UXML template
-            var template = Resources.Load<VisualTreeAsset>("ExternalConditionDrawer");
-            if (template == null)
+            var conditionProviderField = contentRoot.Q<ObjectField>("condition-provider-field");
+            var errorContainer = contentRoot.Q<VisualElement>("error-container");
+            var errorLabel = contentRoot.Q<Label>("error-label");
+            var hasErrorElements = errorContainer != null && errorLabel != null;
+
+            if (!hasErrorElements)
             {
-                Debug.LogError("Could not load ExternalConditionDrawer.uxml from Resources folder");
-                return new Label("Missing UXML Template");
+                Debug.LogWarning("Missing error UI elements for ExternalCondition drawer");
             }
 
-            var root = template.CloneTree();
-
-            // Apply Octoputs stylesheet
-            var styleSheet = Resources.Load<StyleSheet>("OctoputsListStyles");
-            if (styleSheet != null)
-            {
-                root.styleSheets.Add(styleSheet);
-            }
-
-            // Get UI elements
-            var conditionProviderField = root.Q<ObjectField>("condition-provider-field");
-            var errorContainer = root.Q<VisualElement>("error-container");
-            var errorLabel = root.Q<Label>("error-label");
-            
-
-            // Find the ConditionProvider property
             var conditionProviderProp = property.FindPropertyRelative("conditionProvider");
             if (conditionProviderProp == null)
             {
-                return new Label("ConditionProvider property not found");
+                Debug.LogError("ConditionProvider property not found on ExternalCondition");
+                return;
             }
 
-            // Configure ObjectField settings (binding is handled by UXML)
-            conditionProviderField.objectType = typeof(Object);
-            conditionProviderField.allowSceneObjects = true;
+            if (conditionProviderField != null)
+            {
+                conditionProviderField.objectType = typeof(Object);
+                conditionProviderField.allowSceneObjects = true;
 
-            // Validation function
+                conditionProviderField.BindProperty(conditionProviderProp);
+
+                conditionProviderField.RegisterValueChangedCallback(_ => ValidateConditionProvider());
+            }
+
+            ValidateConditionProvider();
+
             void ValidateConditionProvider()
             {
+                if (!hasErrorElements)
+                {
+                    return;
+                }
+
                 var conditionProvider = conditionProviderProp.objectReferenceValue;
 
                 if (conditionProvider == null)
                 {
-                    // Hide error when no object is assigned
                     errorContainer.style.display = DisplayStyle.None;
                     return;
                 }
 
-                // Check if the object implements IBooleanCondition
                 if (conditionProvider is IBooleanCondition)
                 {
-                    // Valid - hide error
                     errorContainer.style.display = DisplayStyle.None;
                 }
                 else
                 {
-                    // Invalid - show error and null out the reference
-                    errorLabel.text = $"'{conditionProvider.GetType().Name}' does not implement IBooleanCondition interface";
+                    errorLabel.text =
+                        $"'{conditionProvider.GetType().Name}' does not implement IBooleanCondition interface";
                     errorContainer.style.display = DisplayStyle.Flex;
 
-                    // Clear the invalid reference
                     conditionProviderProp.objectReferenceValue = null;
                     conditionProviderProp.serializedObject.ApplyModifiedProperties();
                 }
             }
-
-            // Initial validation
-            ValidateConditionProvider();
-
-            // Listen for changes to the ConditionProvider field
-            conditionProviderField.RegisterValueChangedCallback(evt =>
-            {
-                ValidateConditionProvider();
-            });
-
-            return root;
         }
     }
 }

--- a/Editor/Conditions/Resources/CombinatoryConditionDrawer.uxml
+++ b/Editor/Conditions/Resources/CombinatoryConditionDrawer.uxml
@@ -1,0 +1,6 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:VisualElement name="combinatory-condition-root" class="jungle-section-content">
+        <uie:PropertyField name="logical-operator-field" binding-path="logicalOperator" label="Logical Operator" class="jungle-marginfield" />
+        <ui:VisualElement name="conditions-content" class="jungle-runtime-list" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/Conditions/Resources/CombinatoryConditionDrawer.uxml.meta
+++ b/Editor/Conditions/Resources/CombinatoryConditionDrawer.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f8a9cb8f91e42d88fa0d7ce2b5b2a7f
+timeCreated: 1738876801

--- a/Editor/Conditions/Resources/ConditionDrawer.uxml
+++ b/Editor/Conditions/Resources/ConditionDrawer.uxml
@@ -1,0 +1,12 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:VisualElement name="condition-root" class="jungle-section">
+        <ui:VisualElement name="condition-header" class="jungle-section-content">
+            <ui:Label name="condition-title" class="jungle-section-header" text="Condition" />
+            <uie:PropertyField name="negate-condition-field" binding-path="negateCondition" label="Negate Condition" class="jungle-marginfield" />
+            <ui:VisualElement name="condition-info" class="jungle-runtime-info" style="display: none;">
+                <ui:Label name="condition-description" class="pkg-desc" text="" />
+            </ui:VisualElement>
+        </ui:VisualElement>
+        <ui:VisualElement name="condition-content" class="jungle-section-content" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/Conditions/Resources/ConditionDrawer.uxml.meta
+++ b/Editor/Conditions/Resources/ConditionDrawer.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d3c6452b2b0b4c2a86b60ae8f9480945
+timeCreated: 1738876800

--- a/Editor/Conditions/Resources/ExternalConditionDrawer.uxml
+++ b/Editor/Conditions/Resources/ExternalConditionDrawer.uxml
@@ -1,8 +1,8 @@
-﻿<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
-    <ui:VisualElement name="external-condition-root" class="octoputs-external-condition-container">
-        <uie:ObjectField name="condition-provider-field" label="Condition Provider" class="octoputs-object-field" binding-path="ConditionProvider" />
-        <ui:VisualElement name="error-container" class="octoputs-error-container" style="display: none;">
-            <ui:Label name="error-label" text="Error message" class="octoputs-error-label" />
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:VisualElement name="external-condition-root" class="jungle-section-content">
+        <uie:ObjectField name="condition-provider-field" label="Condition Provider" binding-path="conditionProvider" class="jungle-marginfield" />
+        <ui:VisualElement name="error-container" class="jungle-warning" style="display: none;">
+            <ui:Label name="error-label" text="" class="pkg-desc" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
## Summary
- introduce a shared `ConditionDrawerBase` that loads the Jungle UXML/styling, exposes negate controls, and auto-wires JungleList attributes for managed reference conditions
- add concrete drawers for `Condition`, `CombinatoryCondition`, and `ExternalCondition` that rely on the shared template and dedicated UXML layouts
- create UXML resources for the condition editors so the inspectors adopt Jungle styling and structured layouts

## Testing
- not run (Unity editor tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d405da01f08320a69ffc0fabdf4cb6