### PR TITLE
Support SerializedReference selections in class picker

### DIFF
--- a/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
+++ b/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
@@ -17,7 +17,10 @@ namespace Jungle.Editor
 
             var propertyField = new PropertyField(property);
 
-            if (baseType != null && typeof(Component).IsAssignableFrom(baseType))
+            var supportsComponents = baseType != null && typeof(Component).IsAssignableFrom(baseType);
+            var supportsManagedReference = property.propertyType == SerializedPropertyType.ManagedReference;
+
+            if (baseType != null && (supportsComponents || supportsManagedReference))
             {
                 var isInitialized = false;
                 propertyField.RegisterCallback<AttachToPanelEvent>(_ =>
@@ -34,7 +37,7 @@ namespace Jungle.Editor
             else
             {
                 Debug.LogWarning(
-                    $"JungleClassSelectionAttribute requires a Component type but '{baseType?.Name ?? fieldInfo?.FieldType.Name}' does not inherit from Component."
+                    $"JungleClassSelectionAttribute requires a valid base type but '{baseType?.Name ?? fieldInfo?.FieldType.Name}' is not supported."
                 );
             }
 


### PR DESCRIPTION
## Summary
- extend SetupFieldWithClassSelectionButton to handle managed reference properties alongside component references
- add helpers to create managed reference instances when a class is chosen from the selection popup
- update JungleClassSelectionAttributeDrawer to enable the selector for SerializeReference-backed fields

## Testing
- not run (Unity editor tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d40f561a50832094695a34ca8f15f4