### PR TITLE
Avoid removing property field before wrapping

### DIFF
--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -99,9 +99,6 @@ namespace Jungle.Editor
             var parent = propertyField.parent;
             var index = parent.IndexOf(propertyField);
 
-            // Remove the PropertyField from its current parent
-            parent.Remove(propertyField);
-
             // Configure the PropertyField to grow and fill available space
             propertyField.style.flexGrow = 1;
 


### PR DESCRIPTION
## Summary
- stop explicitly removing the property field from its parent before wrapping it in the container
- rely on UIElements to reparent the field when it is added to the container, preventing hierarchy modification errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d46a57ea40832080a6c724afe8e4cf