### PR TITLE
Bind class selection property field

### DIFF
--- a/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
+++ b/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
@@ -16,6 +16,7 @@ namespace Jungle.Editor
             var baseType = classSelectionAttribute.BaseType ?? fieldInfo?.FieldType;
 
             var propertyField = new PropertyField(property);
+            propertyField.BindProperty(property);
 
             var supportsComponents = baseType != null && typeof(Component).IsAssignableFrom(baseType);
             var supportsManagedReference = property.propertyType == SerializedPropertyType.ManagedReference;


### PR DESCRIPTION
## Summary
- bind the JungleClassSelection property field directly to its serialized property so custom drawers can render correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d46eca28e48320ba377d7bdf7fd0bd