### PR TITLE
Handle managed reference binding for condition drawer

### DIFF
--- a/Editor/Conditions/ConditionDrawerBase.cs
+++ b/Editor/Conditions/ConditionDrawerBase.cs
@@ -60,7 +60,14 @@ namespace Jungle.Editor.Conditions
 
             InitializeContent(contentRoot, property);
 
-            root.BindProperty(property);
+            if (property.propertyType == SerializedPropertyType.ManagedReference)
+            {
+                root.Bind(property.serializedObject);
+            }
+            else
+            {
+                root.BindProperty(property);
+            }
 
             ProcessJungleListAttributes(root, property);
 


### PR DESCRIPTION
## Summary
- avoid binding condition drawer root directly to managed reference properties
- bind the root visual element to the serialized object when drawing managed reference conditions to prevent console warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d51327d1f88320840bbd685b8667b2