### PR TITLE
Fix managed reference binding in condition drawers

### DIFF
--- a/Editor/Conditions/CombinatoryConditionDrawer.cs
+++ b/Editor/Conditions/CombinatoryConditionDrawer.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
+using EditorUtils = Jungle.Editor.EditorUtils;
 
 namespace Jungle.Editor.Conditions
 {
@@ -31,7 +32,10 @@ namespace Jungle.Editor.Conditions
                 return;
             }
 
-            logicalOperatorField?.BindProperty(logicalOperatorProperty);
+            if (logicalOperatorField != null)
+            {
+                EditorUtils.BindPropertySafely(logicalOperatorField, logicalOperatorProperty);
+            }
         }
     }
 }

--- a/Editor/Conditions/ConditionDrawer.cs
+++ b/Editor/Conditions/ConditionDrawer.cs
@@ -62,7 +62,7 @@ namespace Jungle.Editor.Conditions
                 var fieldPropertyCopy = fieldProperty.Copy();
                 var propertyField = new PropertyField(fieldPropertyCopy);
                 propertyField.AddToClassList("jungle-marginfield");
-                propertyField.BindProperty(fieldProperty);
+                EditorUtils.BindPropertySafely(propertyField, fieldProperty);
                 AttachClassSelectionButtonIfNeeded(propertyField, field, fieldProperty);
                 contentRoot.Add(propertyField);
             }

--- a/Editor/Conditions/ConditionDrawerBase.cs
+++ b/Editor/Conditions/ConditionDrawerBase.cs
@@ -90,7 +90,10 @@ namespace Jungle.Editor.Conditions
 
                     ProcessJungleListAttributes(root, property);
 
-                    root.BindProperty(property);
+                    if (property.propertyType != SerializedPropertyType.ManagedReference)
+                    {
+                        root.BindProperty(property);
+                    }
 
                     BindNegateConditionField(root, property);
                 }
@@ -250,8 +253,7 @@ namespace Jungle.Editor.Conditions
                 return;
             }
 
-            negateConditionField.Unbind();
-            negateConditionField.BindProperty(negateConditionProperty);
+            EditorUtils.BindPropertySafely(negateConditionField, negateConditionProperty);
         }
 
         private static void AddStyleSheet(VisualElement element, string styleSheetPath)

--- a/Editor/Conditions/ExternalConditionDrawer.cs
+++ b/Editor/Conditions/ExternalConditionDrawer.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
+using EditorUtils = Jungle.Editor.EditorUtils;
 
 namespace Jungle.Editor.Conditions
 {
@@ -38,7 +39,7 @@ namespace Jungle.Editor.Conditions
                 conditionProviderField.objectType = typeof(Object);
                 conditionProviderField.allowSceneObjects = true;
 
-                conditionProviderField.BindProperty(conditionProviderProp);
+                EditorUtils.BindPropertySafely(conditionProviderField, conditionProviderProp);
 
                 conditionProviderField.RegisterValueChangedCallback(_ => ValidateConditionProvider());
             }

--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -12,6 +12,28 @@ namespace Jungle.Editor
     public static class EditorUtils
     {
         /// <summary>
+        /// Binds a UI Toolkit element to a property while handling managed references gracefully.
+        /// </summary>
+        public static void BindPropertySafely(BindableElement element, SerializedProperty property)
+        {
+            if (element == null || property == null)
+            {
+                return;
+            }
+
+            element.Unbind();
+
+            if (property.propertyType == SerializedPropertyType.ManagedReference)
+            {
+                element.bindingPath = property.propertyPath;
+                element.Bind(property.serializedObject);
+                return;
+            }
+
+            element.BindProperty(property);
+        }
+
+        /// <summary>
         /// Gets all available types that inherit from a specified base type using TypeCache
         /// </summary>
         /// <typeparam name="T">The base type to search for subclasses of</typeparam>

--- a/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
+++ b/Editor/Utils/JungleClassSelectionAttributeDrawer.cs
@@ -16,7 +16,7 @@ namespace Jungle.Editor
             var baseType = classSelectionAttribute.BaseType ?? fieldInfo?.FieldType;
 
             var propertyField = new PropertyField(property);
-            propertyField.BindProperty(property);
+            EditorUtils.BindPropertySafely(propertyField, property);
 
             var supportsComponents = baseType != null && typeof(Component).IsAssignableFrom(baseType);
             var supportsManagedReference = property.propertyType == SerializedPropertyType.ManagedReference;


### PR DESCRIPTION
## Summary
- add a shared helper to bind UI Toolkit elements without triggering managed reference errors
- update condition drawers and class selection drawer to use the helper
- skip binding the root element when drawing managed reference conditions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d51d5c820c8320b65a33df42376346