### PR TITLE
Style class selection fields with rounded outline

### DIFF
--- a/Editor/Resources/JungleEditorStyles.uss
+++ b/Editor/Resources/JungleEditorStyles.uss
@@ -268,6 +268,32 @@
     align-items: flex-start;
 }
 
+.jungle-class-selector-field .unity-base-field__input {
+    padding: 0;
+    background-color: transparent;
+    border-width: 0;
+}
+
+.jungle-add-inline-wrapper {
+    flex-grow: 1;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 4px;
+    padding: 2px 2px 2px 8px;
+    border-width: 1px;
+    border-color: var(--unity-colors-default-border);
+    border-radius: 9999px;
+    background-color: var(--unity-colors-default-background);
+}
+
+.jungle-add-inline-wrapper > :first-child {
+    flex-grow: 1;
+}
+
+.jungle-add-inline-wrapper > .jungle-add-inline-button {
+    margin-left: 6px;
+}
+
 .jungle-class-selector-button-column {
     flex-direction: column;
     align-items: stretch;

--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -101,6 +101,7 @@ namespace Jungle.Editor
 
             // Configure the PropertyField to grow and fill available space
             propertyField.style.flexGrow = 1;
+            propertyField.AddToClassList("jungle-class-selector-field");
 
 
             // Create the button column so that we can place the clear button above the selector


### PR DESCRIPTION
## Summary
- mark class selector property fields with a dedicated USS class during setup
- style the inline wrapper so the field and button share a rounded outline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55c40519883208bfef802c6b79bc2