### PR TITLE
Simplify inline class selector wrapper

### DIFF
--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -97,57 +97,53 @@ namespace Jungle.Editor
                 style =
                 {
                     flexDirection = FlexDirection.Row,
-                    alignItems = Align.Center
+                    alignItems = Align.FlexStart
                 }
             };
-
 
             // Get the parent and index of the original PropertyField
             var parent = propertyField.parent;
             var index = parent.IndexOf(propertyField);
 
-
             // Configure the PropertyField to grow and fill available space
             propertyField.style.flexGrow = 1;
             propertyField.AddToClassList("jungle-class-selector-field");
-
 
             // Create the button column so that we can place the clear button above the selector
             var buttonColumn = new VisualElement();
             buttonColumn.AddToClassList("jungle-class-selector-button-column");
 
             // Create the main jungle themed selection button
-
-            var addButton = new Button();
-            addButton.text = "+";
-            addButton.tooltip = "Select or change type";
+            var addButton = new Button
+            {
+                text = "+",
+                tooltip = "Select or change type"
+            };
             addButton.AddToClassList("jungle-add-inline-button");
 
             // Create the clear button which will reset the value to null
-            var clearButton = new Button();
-            clearButton.text = "✕";
-            clearButton.tooltip = "Clear selection";
+            var clearButton = new Button
+            {
+                text = "✕",
+                tooltip = "Clear selection"
+            };
             clearButton.style.display = DisplayStyle.None;
             clearButton.AddToClassList("jungle-custom-list-remove-button");
             clearButton.AddToClassList("jungle-class-selector-clear-button");
 
             // Remove the PropertyField from its current parent
             parent.Remove(propertyField);
-            // Insert the container at the original PropertyField's position
-
-            // Configure the PropertyField to grow and fill available space
-            propertyField.style.flexGrow = 1;
 
             // Add both elements to the container
             container.Add(propertyField);
-            container.Add(addButton);
+            container.Add(buttonColumn);
+            buttonColumn.Add(clearButton);
+
             AttachJungleEditorStyles(container);
+            AttachJungleEditorStyles(propertyField);
+            AttachJungleEditorStyles(buttonColumn);
             container.AddToClassList("jungle-class-selector-container");
 
-            addButton.AddToClassList("jungle-add-inline-button");
-
-
-            // Setup button click handler
             void UpdateButtonState()
             {
                 var serializedObject = property.serializedObject;
@@ -212,76 +208,98 @@ namespace Jungle.Editor
             };
 
 
-            // Add both elements to the container
-            container.Add(propertyField);
-            buttonColumn.Add(clearButton);
-            buttonColumn.Add(addButton);
-            container.Add(buttonColumn);
-
             propertyField.TrackPropertyValue(property, _ => UpdateButtonState());
             UpdateButtonState();
 
             const string inlineWrapperClass = "jungle-add-inline-wrapper";
 
-            if (index >= 0 && index < parent.childCount - 1)
-                parent.Insert(index, container);
+            parent.Insert(index, container);
 
-            bool TryAttachButton()
+            VisualElement inlineWrapper = null;
+            var inlineAttachmentComplete = false;
+            var awaitingGeometry = false;
+
+            bool AttachInlineButton()
             {
-                // unity-content contains the label + base field when the property renders with a label
-                var unityContent = propertyField.Q(className: "unity-content");
-                var baseField = unityContent?.Q(className: "unity-base-field") ??
-                                propertyField.Q(className: "unity-base-field");
+                var contentContainer = propertyField.contentContainer;
 
-                if (baseField == null)
+                if (contentContainer.childCount == 0)
                 {
                     return false;
                 }
 
-
-                var inputContainer = baseField.Q(className: "unity-base-field__input") ?? baseField;
-
-
-                if (inputContainer.Q(className: inlineWrapperClass) != null)
+                if (inlineWrapper == null)
                 {
-                    return true;
+                    inlineWrapper = new VisualElement();
+                    inlineWrapper.AddToClassList(inlineWrapperClass);
+                    AttachJungleEditorStyles(inlineWrapper);
                 }
 
-                var inlineWrapper = new VisualElement();
-                inlineWrapper.AddToClassList(inlineWrapperClass);
-
-                inlineWrapper.style.flexDirection = FlexDirection.Row;
-                inlineWrapper.style.alignItems = Align.Center;
-                inlineWrapper.style.flexGrow = 1;
-
-
-                // Move existing children into the wrapper so the button sits inside the same outlined group
-                while (inputContainer.childCount > 0)
+                if (inlineWrapper.parent != contentContainer)
                 {
-                    inlineWrapper.Add(inputContainer[0]);
+                    var fieldElement = contentContainer[0];
+                    contentContainer.Insert(0, inlineWrapper);
+                    inlineWrapper.Add(fieldElement);
                 }
 
+                if (!inlineWrapper.Contains(addButton))
+                {
+                    inlineWrapper.Add(addButton);
+                }
 
-                inlineWrapper.Add(addButton);
-                inputContainer.Add(inlineWrapper);
-
+                inlineAttachmentComplete = true;
                 return true;
             }
 
-            if (!TryAttachButton())
+            void UseFallbackColumn()
             {
-                // Delay attachment until the visual tree of the PropertyField is fully built.
-                propertyField.schedule.Execute(() =>
+                if (addButton.parent != buttonColumn)
                 {
-                    if (!TryAttachButton())
-                    {
-                        // Try once more after a small delay to handle asynchronous bindings.
-                        propertyField.schedule.Execute(_ => TryAttachButton()).ExecuteLater(50);
-                    }
-                });
+                    buttonColumn.Add(addButton);
+                }
+
+                inlineAttachmentComplete = true;
             }
 
-            parent.Insert(index, container);
+            void AttemptInlineAttachment()
+            {
+                if (inlineAttachmentComplete)
+                {
+                    return;
+                }
+
+                if (AttachInlineButton())
+                {
+                    if (awaitingGeometry)
+                    {
+                        propertyField.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                        awaitingGeometry = false;
+                    }
+
+                    return;
+                }
+
+                if (!awaitingGeometry)
+                {
+                    propertyField.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                    awaitingGeometry = true;
+                }
+            }
+
+            void OnGeometryChanged(GeometryChangedEvent evt)
+            {
+                propertyField.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                awaitingGeometry = false;
+
+                if (AttachInlineButton())
+                {
+                    return;
+                }
+
+                UseFallbackColumn();
+            }
+
+            AttemptInlineAttachment();
         }
 
         private static void AttachJungleEditorStyles(VisualElement element)


### PR DESCRIPTION
## Summary
- wrap the property field content inside the jungle inline wrapper so the rounded outline and themed button colors apply without depending on Unity-generated class names
- simplify inline attachment by assuming the single generated input child, reparenting it into the wrapper, and waiting on one geometry change before falling back to the button column
- keep the add button inline with the field whenever possible so attribute-created selectors retain the jungle styling while still exposing the column fallback when needed

## Testing
- not run (Unity editor tooling)

------
https://chatgpt.com/codex/tasks/task_e_68d560493de88320b1dd6d2cdbf98c1f