### PR TITLE
Move class selector styling to USS

### DIFF
--- a/Editor/Resources/JungleEditorStyles.uss
+++ b/Editor/Resources/JungleEditorStyles.uss
@@ -265,7 +265,13 @@
 /* Class selector field layout */
 .jungle-class-selector-container {
     flex-direction: row;
-    align-items: flex-start;
+    align-items: center;
+    column-gap: 4px;
+}
+
+.jungle-class-selector-field {
+    flex-grow: 1;
+    flex-shrink: 1;
 }
 
 .jungle-class-selector-field .unity-base-field__input {
@@ -288,6 +294,7 @@
 
 .jungle-add-inline-wrapper > :first-child {
     flex-grow: 1;
+    flex-shrink: 1;
 }
 
 .jungle-add-inline-wrapper > .jungle-add-inline-button {
@@ -312,10 +319,28 @@
     border-color: #7BCBA4;
 }
 
+.jungle-add-inline-button.jungle-class-selector-button--has-value:hover {
+    background-color: #37905F;
+    border-color: #94D8B8;
+}
+
+.jungle-add-inline-button.jungle-class-selector-button--has-value:active {
+    background-color: #256845;
+    border-color: #63B78E;
+}
+
 .jungle-class-selector-clear-button {
     background-color: rgba(232, 138, 138, 0.9);
     border-color: #E88A8A;
     color: white;
+}
+
+.jungle-class-selector-clear-button--hidden {
+    display: none;
+}
+
+.jungle-class-selector-clear-button--visible {
+    display: flex;
 }
 
 .jungle-class-selector-clear-button:hover {

--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -92,62 +92,51 @@ namespace Jungle.Editor
 
 
             // Create a container to hold both the PropertyField and the plus button
-            var container = new VisualElement
-            {
-                style =
-                {
-                    flexDirection = FlexDirection.Row,
-                    alignItems = Align.Center
-                }
-            };
-
+            var container = new VisualElement();
 
             // Get the parent and index of the original PropertyField
             var parent = propertyField.parent;
             var index = parent.IndexOf(propertyField);
 
-
             // Configure the PropertyField to grow and fill available space
-            propertyField.style.flexGrow = 1;
             propertyField.AddToClassList("jungle-class-selector-field");
-
 
             // Create the button column so that we can place the clear button above the selector
             var buttonColumn = new VisualElement();
             buttonColumn.AddToClassList("jungle-class-selector-button-column");
 
             // Create the main jungle themed selection button
-
-            var addButton = new Button();
-            addButton.text = "+";
-            addButton.tooltip = "Select or change type";
+            var addButton = new Button
+            {
+                text = "+",
+                tooltip = "Select or change type"
+            };
             addButton.AddToClassList("jungle-add-inline-button");
 
             // Create the clear button which will reset the value to null
-            var clearButton = new Button();
-            clearButton.text = "✕";
-            clearButton.tooltip = "Clear selection";
-            clearButton.style.display = DisplayStyle.None;
+            var clearButton = new Button
+            {
+                text = "✕",
+                tooltip = "Clear selection"
+            };
             clearButton.AddToClassList("jungle-custom-list-remove-button");
             clearButton.AddToClassList("jungle-class-selector-clear-button");
+            clearButton.AddToClassList("jungle-class-selector-clear-button--hidden");
 
             // Remove the PropertyField from its current parent
             parent.Remove(propertyField);
-            // Insert the container at the original PropertyField's position
-
-            // Configure the PropertyField to grow and fill available space
-            propertyField.style.flexGrow = 1;
 
             // Add both elements to the container
             container.Add(propertyField);
-            container.Add(addButton);
+            container.Add(buttonColumn);
+            buttonColumn.Add(clearButton);
+            buttonColumn.Add(addButton);
+
             AttachJungleEditorStyles(container);
+            AttachJungleEditorStyles(propertyField);
+            AttachJungleEditorStyles(buttonColumn);
             container.AddToClassList("jungle-class-selector-container");
 
-            addButton.AddToClassList("jungle-add-inline-button");
-
-
-            // Setup button click handler
             void UpdateButtonState()
             {
                 var serializedObject = property.serializedObject;
@@ -167,7 +156,8 @@ namespace Jungle.Editor
                 addButton.text = hasValue ? "⇄" : "+";
                 addButton.EnableInClassList("jungle-class-selector-button--has-value", hasValue);
 
-                clearButton.style.display = hasValue ? DisplayStyle.Flex : DisplayStyle.None;
+                clearButton.EnableInClassList("jungle-class-selector-clear-button--visible", hasValue);
+                clearButton.EnableInClassList("jungle-class-selector-clear-button--hidden", !hasValue);
             }
 
             addButton.clicked += () =>
@@ -212,76 +202,60 @@ namespace Jungle.Editor
             };
 
 
-            // Add both elements to the container
-            container.Add(propertyField);
-            buttonColumn.Add(clearButton);
-            buttonColumn.Add(addButton);
-            container.Add(buttonColumn);
-
             propertyField.TrackPropertyValue(property, _ => UpdateButtonState());
             UpdateButtonState();
 
-            const string inlineWrapperClass = "jungle-add-inline-wrapper";
-
-            if (index >= 0 && index < parent.childCount - 1)
-                parent.Insert(index, container);
-
-            bool TryAttachButton()
-            {
-                // unity-content contains the label + base field when the property renders with a label
-                var unityContent = propertyField.Q(className: "unity-content");
-                var baseField = unityContent?.Q(className: "unity-base-field") ??
-                                propertyField.Q(className: "unity-base-field");
-
-                if (baseField == null)
-                {
-                    return false;
-                }
-
-
-                var inputContainer = baseField.Q(className: "unity-base-field__input") ?? baseField;
-
-
-                if (inputContainer.Q(className: inlineWrapperClass) != null)
-                {
-                    return true;
-                }
-
-                var inlineWrapper = new VisualElement();
-                inlineWrapper.AddToClassList(inlineWrapperClass);
-
-                inlineWrapper.style.flexDirection = FlexDirection.Row;
-                inlineWrapper.style.alignItems = Align.Center;
-                inlineWrapper.style.flexGrow = 1;
-
-
-                // Move existing children into the wrapper so the button sits inside the same outlined group
-                while (inputContainer.childCount > 0)
-                {
-                    inlineWrapper.Add(inputContainer[0]);
-                }
-
-
-                inlineWrapper.Add(addButton);
-                inputContainer.Add(inlineWrapper);
-
-                return true;
-            }
-
-            if (!TryAttachButton())
-            {
-                // Delay attachment until the visual tree of the PropertyField is fully built.
-                propertyField.schedule.Execute(() =>
-                {
-                    if (!TryAttachButton())
-                    {
-                        // Try once more after a small delay to handle asynchronous bindings.
-                        propertyField.schedule.Execute(_ => TryAttachButton()).ExecuteLater(50);
-                    }
-                });
-            }
-
             parent.Insert(index, container);
+
+            VisualElement inlineWrapper = null;
+            IVisualElementScheduledItem pendingInlineRetry = null;
+
+            void EnsureInlineWrapper()
+            {
+                var valueInputContainer = propertyField.contentContainer;
+                var inputParent = valueInputContainer.parent;
+
+                if (inputParent == null)
+                {
+                    if (pendingInlineRetry == null)
+                    {
+                        pendingInlineRetry = propertyField.schedule.Execute(() =>
+                        {
+                            pendingInlineRetry = null;
+                            EnsureInlineWrapper();
+                        });
+                    }
+
+                    return;
+                }
+
+                if (inlineWrapper == null)
+                {
+                    inlineWrapper = new VisualElement();
+                    inlineWrapper.AddToClassList("jungle-add-inline-wrapper");
+                    AttachJungleEditorStyles(inlineWrapper);
+                }
+
+                if (inlineWrapper.parent != inputParent)
+                {
+                    var insertIndex = inputParent.IndexOf(valueInputContainer);
+                    inputParent.Insert(insertIndex, inlineWrapper);
+                }
+
+                if (valueInputContainer.parent != inlineWrapper)
+                {
+                    inlineWrapper.Insert(0, valueInputContainer);
+                }
+
+                if (addButton.parent != inlineWrapper)
+                {
+                    inlineWrapper.Add(addButton);
+                }
+            }
+
+            EnsureInlineWrapper();
+
+            propertyField.RegisterCallback<AttachToPanelEvent>(_ => EnsureInlineWrapper());
         }
 
         private static void AttachJungleEditorStyles(VisualElement element)


### PR DESCRIPTION
## Summary
- rely on JungleEditorStyles USS classes to size and color the inline add button instead of applying inline style overrides
- toggle the clear button visibility with utility classes while reusing the inline wrapper attachment so the themed outline is preserved

## Testing
- not run (Unity editor tooling)

------
https://chatgpt.com/codex/tasks/task_e_68d560493de88320b1dd6d2cdbf98c1f