### PR TITLE
Fix Jungle class selector inline button styling

### DIFF
--- a/Editor/Resources/JungleEditorStyles.uss
+++ b/Editor/Resources/JungleEditorStyles.uss
@@ -145,11 +145,16 @@
     font-size: 14px;
     -unity-font-style: bold;
     -unity-text-align: middle-center;
-    color: white;
+    color: var(--unity-colors-button-text);
     padding: 0;
     margin-left: 8px;
     flex-shrink: 0;
     align-self: center;
+}
+
+.jungle-inline-button-icon {
+    color: inherit;
+    -unity-text-align: middle-center;
 }
 
 .jungle-add-inline-button:hover {

--- a/Editor/Utils/EditorUtils.cs
+++ b/Editor/Utils/EditorUtils.cs
@@ -108,11 +108,15 @@ namespace Jungle.Editor
             buttonColumn.AddToClassList("jungle-class-selector-button-column");
 
             // Create the main jungle themed selection button
+            var addButtonIcon = new Label("+");
+            addButtonIcon.AddToClassList("jungle-inline-button-icon");
+
             var addButton = new Button
             {
-                text = "+",
                 tooltip = "Select or change type"
             };
+            addButton.text = string.Empty;
+            addButton.Add(addButtonIcon);
             addButton.AddToClassList("jungle-add-inline-button");
 
             // Create the clear button which will reset the value to null
@@ -153,11 +157,12 @@ namespace Jungle.Editor
                     hasValue = property.objectReferenceValue != null;
                 }
 
-                addButton.text = hasValue ? "⇄" : "+";
+                addButtonIcon.text = hasValue ? "⇄" : "+";
                 addButton.EnableInClassList("jungle-class-selector-button--has-value", hasValue);
 
                 clearButton.EnableInClassList("jungle-class-selector-clear-button--visible", hasValue);
                 clearButton.EnableInClassList("jungle-class-selector-clear-button--hidden", !hasValue);
+                clearButton.style.display = hasValue ? DisplayStyle.Flex : DisplayStyle.None;
             }
 
             addButton.clicked += () =>


### PR DESCRIPTION
## Summary
- render the Jungle class selector add button icon through a stylable label so it inherits colors from the shared stylesheet
- update the stylesheet to provide a reusable inline button icon style and rely on themed text colors
- hide the clear button entirely when the field is empty while keeping the swap icon state intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6933743f0832094dc1c0ca64c097c