### PR TITLE
Add random condition type

### DIFF
--- a/Scripts/Condition/RandomCondition.cs
+++ b/Scripts/Condition/RandomCondition.cs
@@ -1,0 +1,28 @@
+using System;
+using Jungle.Attributes;
+using UnityEngine;
+
+namespace Jungle.Conditions
+{
+    /// <summary>
+    /// A condition that returns true based on a configurable probability.
+    /// Useful for triggering random events or adding variability to behaviours.
+    /// </summary>
+    [Serializable]
+    [JungleClassInfo("Random Condition", "Evaluates to true based on a probability threshold", null, "General")]
+    public class RandomCondition : Condition
+    {
+        [SerializeField]
+        [Range(0f, 1f)]
+        private float probability = 0.5f;
+
+        /// <summary>
+        /// Evaluates the random condition.
+        /// </summary>
+        /// <returns>True when the generated random value is below the configured probability.</returns>
+        protected internal override bool IsValidImpl()
+        {
+            return UnityEngine.Random.value < probability;
+        }
+    }
+}

--- a/Scripts/Condition/RandomCondition.cs.meta
+++ b/Scripts/Condition/RandomCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa391392201d4544aba8bdf743effe47


### PR DESCRIPTION
## Summary
- add a new random condition implementation driven by a configurable probability
- expose the condition through class metadata so it can be selected like other conditions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf22925148320ae28179780ed1233