### PR TITLE
Add strongly typed value wrappers

### DIFF
--- a/Scripts/Values/GameDev/AnimationClipValue.cs
+++ b/Scripts/Values/GameDev/AnimationClipValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class AnimationClipValue : LocalValue<AnimationClip>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/AnimationClipValueAsset.cs
+++ b/Scripts/Values/GameDev/AnimationClipValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/AnimationClip Value", fileName = "AnimationClipValue")]
+    public class AnimationClipValueAsset : ValueAsset<AnimationClip>
+    {
+        [SerializeField]
+        private AnimationClip value;
+
+        public override AnimationClip GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/AnimationClipValueComponent.cs
+++ b/Scripts/Values/GameDev/AnimationClipValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class AnimationClipValueComponent : ValueComponent<AnimationClip>
+    {
+        [SerializeField]
+        private AnimationClip value;
+
+        public override AnimationClip GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/AudioClipValue.cs
+++ b/Scripts/Values/GameDev/AudioClipValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class AudioClipValue : LocalValue<AudioClip>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/AudioClipValueAsset.cs
+++ b/Scripts/Values/GameDev/AudioClipValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/AudioClip Value", fileName = "AudioClipValue")]
+    public class AudioClipValueAsset : ValueAsset<AudioClip>
+    {
+        [SerializeField]
+        private AudioClip value;
+
+        public override AudioClip GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/AudioClipValueComponent.cs
+++ b/Scripts/Values/GameDev/AudioClipValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class AudioClipValueComponent : ValueComponent<AudioClip>
+    {
+        [SerializeField]
+        private AudioClip value;
+
+        public override AudioClip GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/GameObjectValue.cs
+++ b/Scripts/Values/GameDev/GameObjectValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class GameObjectValue : LocalValue<GameObject>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/GameObjectValueAsset.cs
+++ b/Scripts/Values/GameDev/GameObjectValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/GameObject Value", fileName = "GameObjectValue")]
+    public class GameObjectValueAsset : ValueAsset<GameObject>
+    {
+        [SerializeField]
+        private GameObject value;
+
+        public override GameObject GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/GameObjectValueComponent.cs
+++ b/Scripts/Values/GameDev/GameObjectValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class GameObjectValueComponent : ValueComponent<GameObject>
+    {
+        [SerializeField]
+        private GameObject value;
+
+        public override GameObject GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/LayerMaskValue.cs
+++ b/Scripts/Values/GameDev/LayerMaskValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class LayerMaskValue : LocalValue<LayerMask>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/LayerMaskValueAsset.cs
+++ b/Scripts/Values/GameDev/LayerMaskValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/LayerMask Value", fileName = "LayerMaskValue")]
+    public class LayerMaskValueAsset : ValueAsset<LayerMask>
+    {
+        [SerializeField]
+        private LayerMask value;
+
+        public override LayerMask GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/LayerMaskValueComponent.cs
+++ b/Scripts/Values/GameDev/LayerMaskValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class LayerMaskValueComponent : ValueComponent<LayerMask>
+    {
+        [SerializeField]
+        private LayerMask value;
+
+        public override LayerMask GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/MaterialValue.cs
+++ b/Scripts/Values/GameDev/MaterialValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class MaterialValue : LocalValue<Material>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/MaterialValueAsset.cs
+++ b/Scripts/Values/GameDev/MaterialValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/Material Value", fileName = "MaterialValue")]
+    public class MaterialValueAsset : ValueAsset<Material>
+    {
+        [SerializeField]
+        private Material value;
+
+        public override Material GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/MaterialValueComponent.cs
+++ b/Scripts/Values/GameDev/MaterialValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class MaterialValueComponent : ValueComponent<Material>
+    {
+        [SerializeField]
+        private Material value;
+
+        public override Material GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/SpriteValue.cs
+++ b/Scripts/Values/GameDev/SpriteValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class SpriteValue : LocalValue<Sprite>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/SpriteValueAsset.cs
+++ b/Scripts/Values/GameDev/SpriteValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/Sprite Value", fileName = "SpriteValue")]
+    public class SpriteValueAsset : ValueAsset<Sprite>
+    {
+        [SerializeField]
+        private Sprite value;
+
+        public override Sprite GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/SpriteValueComponent.cs
+++ b/Scripts/Values/GameDev/SpriteValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class SpriteValueComponent : ValueComponent<Sprite>
+    {
+        [SerializeField]
+        private Sprite value;
+
+        public override Sprite GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/TransformValue.cs
+++ b/Scripts/Values/GameDev/TransformValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [Serializable]
+    public class TransformValue : LocalValue<Transform>
+    {
+    }
+}

--- a/Scripts/Values/GameDev/TransformValueAsset.cs
+++ b/Scripts/Values/GameDev/TransformValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/GameDev/Transform Value", fileName = "TransformValue")]
+    public class TransformValueAsset : ValueAsset<Transform>
+    {
+        [SerializeField]
+        private Transform value;
+
+        public override Transform GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/GameDev/TransformValueComponent.cs
+++ b/Scripts/Values/GameDev/TransformValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.GameDev
+{
+    public class TransformValueComponent : ValueComponent<Transform>
+    {
+        [SerializeField]
+        private Transform value;
+
+        public override Transform GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/BoolValue.cs
+++ b/Scripts/Values/Primitives/BoolValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class BoolValue : LocalValue<bool>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/BoolValueAsset.cs
+++ b/Scripts/Values/Primitives/BoolValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/Bool Value", fileName = "BoolValue")]
+    public class BoolValueAsset : ValueAsset<bool>
+    {
+        [SerializeField]
+        private bool value;
+
+        public override bool GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/BoolValueComponent.cs
+++ b/Scripts/Values/Primitives/BoolValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class BoolValueComponent : ValueComponent<bool>
+    {
+        [SerializeField]
+        private bool value;
+
+        public override bool GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/DoubleValue.cs
+++ b/Scripts/Values/Primitives/DoubleValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class DoubleValue : LocalValue<double>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/DoubleValueAsset.cs
+++ b/Scripts/Values/Primitives/DoubleValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/Double Value", fileName = "DoubleValue")]
+    public class DoubleValueAsset : ValueAsset<double>
+    {
+        [SerializeField]
+        private double value;
+
+        public override double GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/DoubleValueComponent.cs
+++ b/Scripts/Values/Primitives/DoubleValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class DoubleValueComponent : ValueComponent<double>
+    {
+        [SerializeField]
+        private double value;
+
+        public override double GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/FloatValue.cs
+++ b/Scripts/Values/Primitives/FloatValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class FloatValue : LocalValue<float>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/FloatValueAsset.cs
+++ b/Scripts/Values/Primitives/FloatValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/Float Value", fileName = "FloatValue")]
+    public class FloatValueAsset : ValueAsset<float>
+    {
+        [SerializeField]
+        private float value;
+
+        public override float GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/FloatValueComponent.cs
+++ b/Scripts/Values/Primitives/FloatValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class FloatValueComponent : ValueComponent<float>
+    {
+        [SerializeField]
+        private float value;
+
+        public override float GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/IntValue.cs
+++ b/Scripts/Values/Primitives/IntValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class IntValue : LocalValue<int>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/IntValueAsset.cs
+++ b/Scripts/Values/Primitives/IntValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/Int Value", fileName = "IntValue")]
+    public class IntValueAsset : ValueAsset<int>
+    {
+        [SerializeField]
+        private int value;
+
+        public override int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/IntValueComponent.cs
+++ b/Scripts/Values/Primitives/IntValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class IntValueComponent : ValueComponent<int>
+    {
+        [SerializeField]
+        private int value;
+
+        public override int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/LongValue.cs
+++ b/Scripts/Values/Primitives/LongValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class LongValue : LocalValue<long>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/LongValueAsset.cs
+++ b/Scripts/Values/Primitives/LongValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/Long Value", fileName = "LongValue")]
+    public class LongValueAsset : ValueAsset<long>
+    {
+        [SerializeField]
+        private long value;
+
+        public override long GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/LongValueComponent.cs
+++ b/Scripts/Values/Primitives/LongValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class LongValueComponent : ValueComponent<long>
+    {
+        [SerializeField]
+        private long value;
+
+        public override long GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/StringValue.cs
+++ b/Scripts/Values/Primitives/StringValue.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Jungle.Values.Primitives
+{
+    [Serializable]
+    public class StringValue : LocalValue<string>
+    {
+    }
+}

--- a/Scripts/Values/Primitives/StringValueAsset.cs
+++ b/Scripts/Values/Primitives/StringValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Primitives/String Value", fileName = "StringValue")]
+    public class StringValueAsset : ValueAsset<string>
+    {
+        [SerializeField]
+        private string value;
+
+        public override string GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/Primitives/StringValueComponent.cs
+++ b/Scripts/Values/Primitives/StringValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.Primitives
+{
+    public class StringValueComponent : ValueComponent<string>
+    {
+        [SerializeField]
+        private string value;
+
+        public override string GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/AnimationCurveValue.cs
+++ b/Scripts/Values/UnityTypes/AnimationCurveValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class AnimationCurveValue : LocalValue<AnimationCurve>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/AnimationCurveValueAsset.cs
+++ b/Scripts/Values/UnityTypes/AnimationCurveValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/AnimationCurve Value", fileName = "AnimationCurveValue")]
+    public class AnimationCurveValueAsset : ValueAsset<AnimationCurve>
+    {
+        [SerializeField]
+        private AnimationCurve value = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+
+        public override AnimationCurve GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/AnimationCurveValueComponent.cs
+++ b/Scripts/Values/UnityTypes/AnimationCurveValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class AnimationCurveValueComponent : ValueComponent<AnimationCurve>
+    {
+        [SerializeField]
+        private AnimationCurve value = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+
+        public override AnimationCurve GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/BoundsValue.cs
+++ b/Scripts/Values/UnityTypes/BoundsValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class BoundsValue : LocalValue<Bounds>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/BoundsValueAsset.cs
+++ b/Scripts/Values/UnityTypes/BoundsValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Bounds Value", fileName = "BoundsValue")]
+    public class BoundsValueAsset : ValueAsset<Bounds>
+    {
+        [SerializeField]
+        private Bounds value = new Bounds(Vector3.zero, Vector3.one);
+
+        public override Bounds GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/BoundsValueComponent.cs
+++ b/Scripts/Values/UnityTypes/BoundsValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class BoundsValueComponent : ValueComponent<Bounds>
+    {
+        [SerializeField]
+        private Bounds value = new Bounds(Vector3.zero, Vector3.one);
+
+        public override Bounds GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Color32Value.cs
+++ b/Scripts/Values/UnityTypes/Color32Value.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Color32Value : LocalValue<Color32>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Color32ValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Color32ValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Color32 Value", fileName = "Color32Value")]
+    public class Color32ValueAsset : ValueAsset<Color32>
+    {
+        [SerializeField]
+        private Color32 value = new Color32(255, 255, 255, 255);
+
+        public override Color32 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Color32ValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Color32ValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Color32ValueComponent : ValueComponent<Color32>
+    {
+        [SerializeField]
+        private Color32 value = new Color32(255, 255, 255, 255);
+
+        public override Color32 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/ColorValue.cs
+++ b/Scripts/Values/UnityTypes/ColorValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class ColorValue : LocalValue<Color>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/ColorValueAsset.cs
+++ b/Scripts/Values/UnityTypes/ColorValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Color Value", fileName = "ColorValue")]
+    public class ColorValueAsset : ValueAsset<Color>
+    {
+        [SerializeField]
+        private Color value = Color.white;
+
+        public override Color GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/ColorValueComponent.cs
+++ b/Scripts/Values/UnityTypes/ColorValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class ColorValueComponent : ValueComponent<Color>
+    {
+        [SerializeField]
+        private Color value = Color.white;
+
+        public override Color GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/GradientValue.cs
+++ b/Scripts/Values/UnityTypes/GradientValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class GradientValue : LocalValue<Gradient>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/GradientValueAsset.cs
+++ b/Scripts/Values/UnityTypes/GradientValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Gradient Value", fileName = "GradientValue")]
+    public class GradientValueAsset : ValueAsset<Gradient>
+    {
+        [SerializeField]
+        private Gradient value = new Gradient();
+
+        public override Gradient GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/GradientValueComponent.cs
+++ b/Scripts/Values/UnityTypes/GradientValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class GradientValueComponent : ValueComponent<Gradient>
+    {
+        [SerializeField]
+        private Gradient value = new Gradient();
+
+        public override Gradient GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/QuaternionValue.cs
+++ b/Scripts/Values/UnityTypes/QuaternionValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class QuaternionValue : LocalValue<Quaternion>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/QuaternionValueAsset.cs
+++ b/Scripts/Values/UnityTypes/QuaternionValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Quaternion Value", fileName = "QuaternionValue")]
+    public class QuaternionValueAsset : ValueAsset<Quaternion>
+    {
+        [SerializeField]
+        private Quaternion value;
+
+        public override Quaternion GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/QuaternionValueComponent.cs
+++ b/Scripts/Values/UnityTypes/QuaternionValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class QuaternionValueComponent : ValueComponent<Quaternion>
+    {
+        [SerializeField]
+        private Quaternion value;
+
+        public override Quaternion GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/RectValue.cs
+++ b/Scripts/Values/UnityTypes/RectValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class RectValue : LocalValue<Rect>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/RectValueAsset.cs
+++ b/Scripts/Values/UnityTypes/RectValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Rect Value", fileName = "RectValue")]
+    public class RectValueAsset : ValueAsset<Rect>
+    {
+        [SerializeField]
+        private Rect value = new Rect(0f, 0f, 1f, 1f);
+
+        public override Rect GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/RectValueComponent.cs
+++ b/Scripts/Values/UnityTypes/RectValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class RectValueComponent : ValueComponent<Rect>
+    {
+        [SerializeField]
+        private Rect value = new Rect(0f, 0f, 1f, 1f);
+
+        public override Rect GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2IntValue.cs
+++ b/Scripts/Values/UnityTypes/Vector2IntValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Vector2IntValue : LocalValue<Vector2Int>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2IntValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Vector2IntValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Vector2Int Value", fileName = "Vector2IntValue")]
+    public class Vector2IntValueAsset : ValueAsset<Vector2Int>
+    {
+        [SerializeField]
+        private Vector2Int value;
+
+        public override Vector2Int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2IntValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Vector2IntValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Vector2IntValueComponent : ValueComponent<Vector2Int>
+    {
+        [SerializeField]
+        private Vector2Int value;
+
+        public override Vector2Int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2Value.cs
+++ b/Scripts/Values/UnityTypes/Vector2Value.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Vector2Value : LocalValue<Vector2>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2ValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Vector2ValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Vector2 Value", fileName = "Vector2Value")]
+    public class Vector2ValueAsset : ValueAsset<Vector2>
+    {
+        [SerializeField]
+        private Vector2 value;
+
+        public override Vector2 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector2ValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Vector2ValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Vector2ValueComponent : ValueComponent<Vector2>
+    {
+        [SerializeField]
+        private Vector2 value;
+
+        public override Vector2 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3IntValue.cs
+++ b/Scripts/Values/UnityTypes/Vector3IntValue.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Vector3IntValue : LocalValue<Vector3Int>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3IntValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Vector3IntValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Vector3Int Value", fileName = "Vector3IntValue")]
+    public class Vector3IntValueAsset : ValueAsset<Vector3Int>
+    {
+        [SerializeField]
+        private Vector3Int value;
+
+        public override Vector3Int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3IntValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Vector3IntValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Vector3IntValueComponent : ValueComponent<Vector3Int>
+    {
+        [SerializeField]
+        private Vector3Int value;
+
+        public override Vector3Int GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3Value.cs
+++ b/Scripts/Values/UnityTypes/Vector3Value.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Vector3Value : LocalValue<Vector3>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3ValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Vector3ValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Vector3 Value", fileName = "Vector3Value")]
+    public class Vector3ValueAsset : ValueAsset<Vector3>
+    {
+        [SerializeField]
+        private Vector3 value;
+
+        public override Vector3 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector3ValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Vector3ValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Vector3ValueComponent : ValueComponent<Vector3>
+    {
+        [SerializeField]
+        private Vector3 value;
+
+        public override Vector3 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector4Value.cs
+++ b/Scripts/Values/UnityTypes/Vector4Value.cs
@@ -1,0 +1,10 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [Serializable]
+    public class Vector4Value : LocalValue<Vector4>
+    {
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector4ValueAsset.cs
+++ b/Scripts/Values/UnityTypes/Vector4ValueAsset.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    [CreateAssetMenu(menuName = "Jungle/Values/Unity/Vector4 Value", fileName = "Vector4Value")]
+    public class Vector4ValueAsset : ValueAsset<Vector4>
+    {
+        [SerializeField]
+        private Vector4 value;
+
+        public override Vector4 GetValue()
+        {
+            return value;
+        }
+    }
+}

--- a/Scripts/Values/UnityTypes/Vector4ValueComponent.cs
+++ b/Scripts/Values/UnityTypes/Vector4ValueComponent.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Jungle.Values.UnityTypes
+{
+    public class Vector4ValueComponent : ValueComponent<Vector4>
+    {
+        [SerializeField]
+        private Vector4 value;
+
+        public override Vector4 GetValue()
+        {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add serializable IValue implementations for primitive types like bool, float, and string
- provide Unity type value wrappers such as vectors, colors, gradients, and curves
- introduce game development value wrappers for engine assets like GameObject, Transform, Sprite, and AudioClip

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfaa2c25c83209e626f1d4d05bec1