### PR TITLE
Add StartStopAction base class

### DIFF
--- a/Scripts/Action.meta
+++ b/Scripts/Action.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7578d296cb314ec7ab04b59223cdb0e0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Action/StartStopAction.cs
+++ b/Scripts/Action/StartStopAction.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Jungle.Actions
+{
+    /// <summary>
+    /// Base class for actions that support starting and stopping their execution.
+    /// </summary>
+    [Serializable]
+    public abstract class StartStopAction : Action
+    {
+        private bool isStarted;
+
+        /// <summary>
+        /// Indicates whether the action has been started.
+        /// </summary>
+        protected bool IsStarted => isStarted;
+
+        /// <summary>
+        /// Starts the action. This method is also invoked when the action is executed.
+        /// </summary>
+        public void Start()
+        {
+            if (isStarted)
+            {
+                return;
+            }
+
+            isStarted = true;
+            OnStart();
+        }
+
+        /// <summary>
+        /// Stops the action if it has been started previously.
+        /// </summary>
+        public void Stop()
+        {
+            if (!isStarted)
+            {
+                return;
+            }
+
+            isStarted = false;
+            OnStop();
+        }
+
+        /// <summary>
+        /// Executes the action. For start/stop actions execution simply starts them.
+        /// </summary>
+        public sealed override void Execute()
+        {
+            Start();
+        }
+
+        /// <summary>
+        /// Called when the action starts.
+        /// </summary>
+        protected abstract void OnStart();
+
+        /// <summary>
+        /// Called when the action stops.
+        /// </summary>
+        protected abstract void OnStop();
+    }
+}

--- a/Scripts/Action/StartStopAction.cs.meta
+++ b/Scripts/Action/StartStopAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a699d0a60ad40568cae2fc077998ced
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add the StartStopAction base class for actions that can be started and stopped
- ensure Execute defers to Start while exposing hooks for start and stop behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e040bd44d08320aa6140bb245e53f5