### PR TITLE
Fix timeline fallback positioning after blocking steps

### DIFF
--- a/Editor/Drawers/ActionSequenceDrawer.cs
+++ b/Editor/Drawers/ActionSequenceDrawer.cs
@@ -254,30 +254,28 @@ namespace Jungle.Editor
             private static float[] CalculateFallbackStartFractions(IReadOnlyList<TimelineEntry> entries, float totalDuration, float fallbackWidthFraction)
             {
                 var result = new float[entries.Count];
-                var hasLastKnownStart = false;
-                var lastKnownStart = 0f;
+                var fallbackPosition = 0f;
 
                 for (var i = 0; i < entries.Count; i++)
                 {
                     var entry = entries[i];
 
+                    float fraction;
                     if (entry.StartTime.HasValue)
                     {
-                        var fraction = Mathf.Clamp01(totalDuration > 0f ? entry.StartTime.Value / totalDuration : 0f);
-                        result[i] = fraction;
-                        lastKnownStart = fraction;
-                        hasLastKnownStart = true;
-                    }
-                    else if (entry.Blocking)
-                    {
-                        var fraction = Mathf.Clamp01(i * fallbackWidthFraction);
-                        result[i] = fraction;
-                        lastKnownStart = fraction;
-                        hasLastKnownStart = true;
+                        fraction = Mathf.Clamp01(totalDuration > 0f ? entry.StartTime.Value / totalDuration : 0f);
+                        fallbackPosition = Mathf.Max(fallbackPosition, fraction);
                     }
                     else
                     {
-                        result[i] = hasLastKnownStart ? lastKnownStart : 0f;
+                        fraction = fallbackPosition;
+                    }
+
+                    result[i] = fraction;
+
+                    if (entry.Blocking)
+                    {
+                        fallbackPosition = Mathf.Clamp01(fraction + fallbackWidthFraction);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- update the fallback position calculation in the action sequence timeline so sequential blocking steps push following entries to later start slots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d0e7cd4c832095640d3f3cc80d40