### PR TITLE
Add new transform and animation process actions

### DIFF
--- a/Docs/ProcessActionIdeas.md
+++ b/Docs/ProcessActionIdeas.md
@@ -1,0 +1,60 @@
+# Unity Process Action Catalogue
+
+This guide outlines newly added process actions tailored for common Unity game development workflows and captures a backlog of additional ideas you can explore next. Each action follows the `ProcessAction` pattern already present in the project, allowing them to be dropped into existing Jungle pipelines with minimal integration work.
+
+## Newly Added Actions
+
+| Action | Category | What it does |
+| --- | --- | --- |
+| `PositionLerpAction` | Transform | Tweens a transform to a target world or local position with curve-driven easing and optional return when stopped. |
+| `RotationLerpAction` | Transform | Smoothly rotates a transform toward target Euler angles with support for local or world space and reversible playback. |
+| `AnimatorTriggerAction` | Animation | Fires a configured Animator trigger on start and optionally resets it on stop so one-off animations can be orchestrated safely. |
+| `AnimatorFloatLerpAction` | Animation | Gradually adjusts a float parameter on an Animator controller, ideal for blending layers, weight transitions, or procedural effects. |
+
+## Backlog of Suggested Process Actions
+
+The following ideas cover a broad spectrum of gameplay and presentation needs. They can be implemented incrementally, following the patterns shown in the new actions above.
+
+### Transform & Motion
+- **PathFollowAction** – Move a transform along a predefined spline or waypoint list with speed controls and looping.
+- **ScalePulseAction** – Continuously pulse an object's scale between two ranges for highlight effects.
+- **TransformShakeAction** – Apply Perlin-noise-based shaking for camera hits or item pickups with adjustable intensity curves.
+- **AnchorSwapAction** – Transition UI elements between anchors or layouts while preserving perceived motion.
+
+### Animation & Rigging
+- **AnimatorBoolLatchAction** – Toggle animator bool parameters with automatic reset rules.
+- **AnimatorLayerWeightAction** – Blend animator layer weights over time for layered animation systems.
+- **AvatarMaskBlendAction** – Swap avatar masks or override controllers and fade them in via layer weights.
+- **TimelineControlAction** – Start, pause, and resume Timeline PlayableDirector instances through process orchestration.
+
+### VFX & Audio
+- **ParticleBurstAction** – Trigger particle systems with configurable burst patterns and optional cleanup on stop.
+- **MaterialEmissionPulseAction** – Animate material emission values for warning lights or spell charging cues.
+- **AudioSnapshotBlendAction** – Crossfade between audio mixer snapshots using durations defined per transition.
+- **DecalFadeAction** – Fade projector or decal materials in and out to mark impacts or area effects.
+
+### Gameplay Systems
+- **PhysicsConstraintAction** – Enable or disable rigidbody constraints or joint properties during scripted sequences.
+- **NavMeshAgentMoveAction** – Command a NavMeshAgent toward a destination and optionally wait for arrival before completing.
+- **ColliderToggleAction** – Toggle collider enable states with deferred reset, useful for interaction windows.
+- **InventoryItemSpawnAction** – Instantiate item prefabs with pooling hooks and signal completion once spawned.
+
+### UI & Interaction
+- **CanvasGroupFadeAction** – Fade UI groups using CanvasGroup alpha, optionally blocking interaction until complete.
+- **InputStateAction** – Enable or disable input maps or action sets to gate player control during cutscenes.
+- **TooltipDisplayAction** – Show contextual tooltips with timers and animation hooks.
+- **CursorStyleAction** – Swap cursor sprites or lock states when hovering over interactive sequences.
+
+### Camera & Presentation
+- **CameraBlendAction** – Blend between Cinemachine virtual cameras or modify blend curves dynamically.
+- **FieldOfViewLerpAction** – Animate camera FOV for dash effects or aim-down-sights transitions.
+- **ColorGradingAction** – Blend post-processing volumes or override weights for dramatic lighting shifts.
+- **LetterboxAction** – Animate screen safe-area bars in/out for cinematic sequences.
+
+### Systems Integration
+- **SaveGameSnapshotAction** – Capture or restore checkpoints by triggering the save system from process sequences.
+- **NetworkRPCAction** – Invoke networked RPC calls within multiplayer contexts while ensuring proper callbacks.
+- **AnalyticsEventAction** – Dispatch analytics events tied to cinematic beats or tutorial completions.
+- **StateMachineAction** – Interface with custom state machines, pushing/popping states as part of a process.
+
+Each suggestion can build on the robust coroutine-driven infrastructure established here. Aim to include validation that surfaces configuration issues early (for example, missing components) to keep authoring experiences smooth inside the editor.

--- a/Scripts/Action/Implementations/Start Stop/Animation/AnimatorFloatLerpAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Animation/AnimatorFloatLerpAction.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections;
+using Jungle.Attributes;
+using Jungle.Utils;
+using Jungle.Values.GameDev;
+using UnityEngine;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo("Tweens an animator float parameter to a target value and optionally reverts it on stop.", "d_AnimationClip")]
+    [Serializable]
+    public class AnimatorFloatLerpAction : ProcessAction
+    {
+        [SerializeReference] private IGameObjectValue targetAnimatorObject = new GameObjectValue();
+        [SerializeField] private string parameterName = "Blend";
+        [SerializeField] private float targetValue = 1f;
+        [SerializeField] private float duration = 0.35f;
+        [SerializeField] private AnimationCurve interpolation = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+        [SerializeField] private bool returnToInitialOnStop = true;
+
+        private Animator cachedAnimator;
+        private float cachedInitialValue;
+        private bool hasCachedInitialValue;
+        private Coroutine activeRoutine;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            var animator = ResolveAnimator();
+            ValidateParameter(animator);
+
+            CacheInitialValue(animator);
+
+            StopActiveRoutine();
+
+            if (duration <= 0f)
+            {
+                animator.SetFloat(parameterName, targetValue);
+                return;
+            }
+
+            var start = animator.GetFloat(parameterName);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpValue(animator, start, targetValue));
+        }
+
+        protected override void OnStop()
+        {
+            if (!returnToInitialOnStop || !hasCachedInitialValue)
+            {
+                return;
+            }
+
+            var animator = cachedAnimator ?? ResolveAnimator();
+
+            StopActiveRoutine();
+
+            if (duration <= 0f)
+            {
+                animator.SetFloat(parameterName, cachedInitialValue);
+                return;
+            }
+
+            var start = animator.GetFloat(parameterName);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpValue(animator, start, cachedInitialValue));
+        }
+
+        private IEnumerator LerpValue(Animator animator, float start, float end)
+        {
+            float time = 0f;
+            var totalDuration = Mathf.Max(0.0001f, duration);
+
+            while (time < totalDuration)
+            {
+                time += Time.deltaTime;
+                var t = Mathf.Clamp01(time / totalDuration);
+                var curved = interpolation.Evaluate(t);
+                animator.SetFloat(parameterName, Mathf.LerpUnclamped(start, end, curved));
+                yield return null;
+            }
+
+            animator.SetFloat(parameterName, end);
+        }
+
+        private Animator ResolveAnimator()
+        {
+            if (targetAnimatorObject == null)
+            {
+                throw new InvalidOperationException("Animator GameObject provider has not been assigned.");
+            }
+
+            var gameObject = targetAnimatorObject.V;
+            if (gameObject == null)
+            {
+                throw new InvalidOperationException("The animator GameObject provider returned a null instance.");
+            }
+
+            cachedAnimator = gameObject.GetComponent<Animator>();
+            if (cachedAnimator == null)
+            {
+                throw new InvalidOperationException($"Animator component was not found on '{gameObject.name}'.");
+            }
+
+            return cachedAnimator;
+        }
+
+        private void ValidateParameter(Animator animator)
+        {
+            if (string.IsNullOrEmpty(parameterName))
+            {
+                throw new InvalidOperationException("Animator float parameter name must be provided before starting the action.");
+            }
+
+            foreach (var parameter in animator.parameters)
+            {
+                if (parameter.type == AnimatorControllerParameterType.Float && parameter.name == parameterName)
+                {
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException($"Animator parameter '{parameterName}' was not found or is not of type float.");
+        }
+
+        private void CacheInitialValue(Animator animator)
+        {
+            cachedInitialValue = animator.GetFloat(parameterName);
+            hasCachedInitialValue = true;
+        }
+
+        private void StopActiveRoutine()
+        {
+            if (activeRoutine == null)
+            {
+                return;
+            }
+
+            CoroutineRunner.StopManagedCoroutine(activeRoutine);
+            activeRoutine = null;
+        }
+    }
+}

--- a/Scripts/Action/Implementations/Start Stop/Animation/AnimatorTriggerAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Animation/AnimatorTriggerAction.cs
@@ -1,0 +1,78 @@
+using System;
+using Jungle.Attributes;
+using Jungle.Values.GameDev;
+using UnityEngine;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo("Fires an animator trigger when the action starts and optionally resets it on stop.", "d_AnimationClip")]
+    [Serializable]
+    public class AnimatorTriggerAction : ProcessAction
+    {
+        [SerializeReference] private IGameObjectValue targetAnimatorObject = new GameObjectValue();
+        [SerializeField] private string triggerName = "Activate";
+        [SerializeField] private bool resetOnStop = true;
+
+        private Animator cachedAnimator;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            var animator = ResolveAnimator();
+
+            if (string.IsNullOrEmpty(triggerName))
+            {
+                throw new InvalidOperationException("Animator trigger name must be provided before starting the action.");
+            }
+
+            animator.SetTrigger(triggerName);
+        }
+
+        protected override void OnStop()
+        {
+            if (!resetOnStop)
+            {
+                return;
+            }
+
+            var animator = cachedAnimator ?? ResolveAnimator();
+            if (string.IsNullOrEmpty(triggerName))
+            {
+                return;
+            }
+
+            animator.ResetTrigger(triggerName);
+        }
+
+        private Animator ResolveAnimator()
+        {
+            if (targetAnimatorObject == null)
+            {
+                throw new InvalidOperationException("Animator GameObject provider has not been assigned.");
+            }
+
+            var gameObject = targetAnimatorObject.V;
+            if (gameObject == null)
+            {
+                throw new InvalidOperationException("The animator GameObject provider returned a null instance.");
+            }
+
+            cachedAnimator = gameObject.GetComponent<Animator>();
+            if (cachedAnimator == null)
+            {
+                throw new InvalidOperationException($"Animator component was not found on '{gameObject.name}'.");
+            }
+
+            return cachedAnimator;
+        }
+    }
+}

--- a/Scripts/Action/Implementations/Start Stop/Objects/PositionLerpAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Objects/PositionLerpAction.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections;
+using Jungle.Attributes;
+using Jungle.Utils;
+using Jungle.Values.GameDev;
+using UnityEngine;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo("Smoothly moves a transform toward a target position with optional return on stop.", "d_MoveTool")]
+    [Serializable]
+    public class PositionLerpAction : ProcessAction
+    {
+        [SerializeReference] private ITransformValue targetTransform = new TransformLocalValue();
+        [SerializeField] private Vector3 targetPosition = Vector3.zero;
+        [SerializeField] private bool useLocalPosition = true;
+        [SerializeField] private float duration = 0.35f;
+        [SerializeField] private AnimationCurve interpolation = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+        [SerializeField] private bool returnToInitialOnStop = true;
+
+        private Vector3 cachedInitialPosition;
+        private bool hasCachedInitialPosition;
+        private Transform resolvedTransform;
+        private Coroutine activeRoutine;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            resolvedTransform = ResolveTargetTransform();
+            CacheInitialPosition(resolvedTransform);
+
+            StopActiveRoutine();
+
+            if (duration <= 0f)
+            {
+                ApplyPosition(resolvedTransform, targetPosition);
+                return;
+            }
+
+            var start = ReadPosition(resolvedTransform);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpPosition(start, targetPosition));
+        }
+
+        protected override void OnStop()
+        {
+            if (resolvedTransform == null)
+            {
+                return;
+            }
+
+            StopActiveRoutine();
+
+            if (!returnToInitialOnStop || !hasCachedInitialPosition)
+            {
+                return;
+            }
+
+            if (duration <= 0f)
+            {
+                ApplyPosition(resolvedTransform, cachedInitialPosition);
+                return;
+            }
+
+            var current = ReadPosition(resolvedTransform);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpPosition(current, cachedInitialPosition));
+        }
+
+        private IEnumerator LerpPosition(Vector3 start, Vector3 end)
+        {
+            var transform = ResolveTargetTransform();
+            float time = 0f;
+            var totalDuration = Mathf.Max(0.0001f, duration);
+
+            while (time < totalDuration)
+            {
+                time += Time.deltaTime;
+                var t = Mathf.Clamp01(time / totalDuration);
+                var curved = interpolation.Evaluate(t);
+                ApplyPosition(transform, Vector3.LerpUnclamped(start, end, curved));
+                yield return null;
+            }
+
+            ApplyPosition(transform, end);
+        }
+
+        private Transform ResolveTargetTransform()
+        {
+            if (targetTransform == null)
+            {
+                throw new InvalidOperationException("Target transform provider has not been assigned.");
+            }
+
+            var transform = targetTransform.V;
+            if (transform == null)
+            {
+                throw new InvalidOperationException("The transform provider returned a null transform instance.");
+            }
+
+            return transform;
+        }
+
+        private void CacheInitialPosition(Transform transform)
+        {
+            cachedInitialPosition = ReadPosition(transform);
+            hasCachedInitialPosition = true;
+        }
+
+        private Vector3 ReadPosition(Transform transform)
+        {
+            return useLocalPosition ? transform.localPosition : transform.position;
+        }
+
+        private void ApplyPosition(Transform transform, Vector3 position)
+        {
+            if (useLocalPosition)
+            {
+                transform.localPosition = position;
+            }
+            else
+            {
+                transform.position = position;
+            }
+        }
+
+        private void StopActiveRoutine()
+        {
+            if (activeRoutine == null)
+            {
+                return;
+            }
+
+            CoroutineRunner.StopManagedCoroutine(activeRoutine);
+            activeRoutine = null;
+        }
+    }
+}

--- a/Scripts/Action/Implementations/Start Stop/Objects/RotationLerpAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Objects/RotationLerpAction.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections;
+using Jungle.Attributes;
+using Jungle.Utils;
+using Jungle.Values.GameDev;
+using UnityEngine;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo("Interpolates a transform toward a target rotation with curve-based easing.", "d_RotateTool")]
+    [Serializable]
+    public class RotationLerpAction : ProcessAction
+    {
+        [SerializeReference] private ITransformValue targetTransform = new TransformLocalValue();
+        [SerializeField] private Vector3 targetEulerAngles = Vector3.zero;
+        [SerializeField] private bool useLocalRotation = true;
+        [SerializeField] private float duration = 0.35f;
+        [SerializeField] private AnimationCurve interpolation = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+        [SerializeField] private bool returnToInitialOnStop = true;
+
+        private Quaternion cachedInitialRotation;
+        private bool hasCachedInitialRotation;
+        private Transform resolvedTransform;
+        private Coroutine activeRoutine;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            resolvedTransform = ResolveTargetTransform();
+            CacheInitialRotation(resolvedTransform);
+
+            StopActiveRoutine();
+
+            var target = Quaternion.Euler(targetEulerAngles);
+
+            if (duration <= 0f)
+            {
+                ApplyRotation(resolvedTransform, target);
+                return;
+            }
+
+            var start = ReadRotation(resolvedTransform);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpRotation(start, target));
+        }
+
+        protected override void OnStop()
+        {
+            if (resolvedTransform == null)
+            {
+                return;
+            }
+
+            StopActiveRoutine();
+
+            if (!returnToInitialOnStop || !hasCachedInitialRotation)
+            {
+                return;
+            }
+
+            if (duration <= 0f)
+            {
+                ApplyRotation(resolvedTransform, cachedInitialRotation);
+                return;
+            }
+
+            var current = ReadRotation(resolvedTransform);
+            activeRoutine = CoroutineRunner.StartManagedCoroutine(LerpRotation(current, cachedInitialRotation));
+        }
+
+        private IEnumerator LerpRotation(Quaternion start, Quaternion end)
+        {
+            var transform = ResolveTargetTransform();
+            float time = 0f;
+            var totalDuration = Mathf.Max(0.0001f, duration);
+
+            while (time < totalDuration)
+            {
+                time += Time.deltaTime;
+                var t = Mathf.Clamp01(time / totalDuration);
+                var curved = interpolation.Evaluate(t);
+                ApplyRotation(transform, Quaternion.LerpUnclamped(start, end, curved));
+                yield return null;
+            }
+
+            ApplyRotation(transform, end);
+        }
+
+        private Transform ResolveTargetTransform()
+        {
+            if (targetTransform == null)
+            {
+                throw new InvalidOperationException("Target transform provider has not been assigned.");
+            }
+
+            var transform = targetTransform.V;
+            if (transform == null)
+            {
+                throw new InvalidOperationException("The transform provider returned a null transform instance.");
+            }
+
+            return transform;
+        }
+
+        private void CacheInitialRotation(Transform transform)
+        {
+            cachedInitialRotation = ReadRotation(transform);
+            hasCachedInitialRotation = true;
+        }
+
+        private Quaternion ReadRotation(Transform transform)
+        {
+            return useLocalRotation ? transform.localRotation : transform.rotation;
+        }
+
+        private void ApplyRotation(Transform transform, Quaternion rotation)
+        {
+            if (useLocalRotation)
+            {
+                transform.localRotation = rotation;
+            }
+            else
+            {
+                transform.rotation = rotation;
+            }
+        }
+
+        private void StopActiveRoutine()
+        {
+            if (activeRoutine == null)
+            {
+                return;
+            }
+
+            CoroutineRunner.StopManagedCoroutine(activeRoutine);
+            activeRoutine = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add process actions for tweening transform position and rotation with easing and optional rewind
- add animator trigger and float parameter actions for orchestrating animation state changes
- document the catalog of available and suggested process actions for future development

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e0d1c2a5008320aa696a0a7c670f96