### PR TITLE
Add timeline and animator sequence actions

### DIFF
--- a/Scripts/Action/Implementations/Start Stop/Animation/AnimatorStateAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Animation/AnimatorStateAction.cs
@@ -1,0 +1,103 @@
+using System;
+using Jungle.Attributes;
+using Jungle.Values.GameDev;
+using UnityEngine;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo(
+        "Plays a specific animator state when the action starts and optionally restores the previous state on stop.",
+        "d_AnimationClip")]
+    [Serializable]
+    public class AnimatorStateAction : ProcessAction
+    {
+        [SerializeReference] private IGameObjectValue targetAnimatorObject = new GameObjectValue();
+        [SerializeField] private string stateName = "StateName";
+        [SerializeField] private int layerIndex;
+        [SerializeField] private bool startFromBeginning = true;
+        [SerializeField] private float startNormalizedTime = 0f;
+        [SerializeField] private bool restorePreviousStateOnStop = true;
+
+        private Animator cachedAnimator;
+        private int previousStateHash;
+        private float previousNormalizedTime;
+        private bool hasPreviousState;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            var animator = ResolveAnimator();
+
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                throw new InvalidOperationException("Animator state name must be provided before starting the action.");
+            }
+
+            if (restorePreviousStateOnStop)
+            {
+                var stateInfo = animator.GetCurrentAnimatorStateInfo(layerIndex);
+                previousStateHash = stateInfo.fullPathHash;
+                previousNormalizedTime = stateInfo.normalizedTime;
+                hasPreviousState = true;
+            }
+            else
+            {
+                hasPreviousState = false;
+            }
+
+            var targetStateHash = Animator.StringToHash(stateName);
+
+            if (startFromBeginning)
+            {
+                animator.Play(targetStateHash, layerIndex, Mathf.Clamp01(startNormalizedTime));
+            }
+            else
+            {
+                animator.Play(targetStateHash, layerIndex);
+            }
+        }
+
+        protected override void OnStop()
+        {
+            if (!restorePreviousStateOnStop || !hasPreviousState)
+            {
+                return;
+            }
+
+            var animator = cachedAnimator ?? ResolveAnimator();
+            var normalizedTime = Mathf.Repeat(previousNormalizedTime, 1f);
+            animator.Play(previousStateHash, layerIndex, normalizedTime);
+        }
+
+        private Animator ResolveAnimator()
+        {
+            if (targetAnimatorObject == null)
+            {
+                throw new InvalidOperationException("Animator GameObject provider has not been assigned.");
+            }
+
+            var gameObject = targetAnimatorObject.V;
+            if (gameObject == null)
+            {
+                throw new InvalidOperationException("The animator GameObject provider returned a null instance.");
+            }
+
+            cachedAnimator = gameObject.GetComponent<Animator>();
+            if (cachedAnimator == null)
+            {
+                throw new InvalidOperationException($"Animator component was not found on '{gameObject.name}'.");
+            }
+
+            return cachedAnimator;
+        }
+    }
+}

--- a/Scripts/Action/Implementations/Start Stop/Animation/PlayableDirectorStartAction.cs
+++ b/Scripts/Action/Implementations/Start Stop/Animation/PlayableDirectorStartAction.cs
@@ -1,0 +1,76 @@
+using System;
+using Jungle.Attributes;
+using Jungle.Values.GameDev;
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace Jungle.Actions
+{
+    [JungleClassInfo(
+        "Starts a PlayableDirector when the action begins and optionally stops it on stop.",
+        "d_AnimationClip")]
+    [Serializable]
+    public class PlayableDirectorStartAction : ProcessAction
+    {
+        [SerializeReference] private IGameObjectValue targetDirectorObject = new GameObjectValue();
+        [SerializeField] private bool restartFromBeginning = true;
+        [SerializeField] private bool stopOnActionStop = true;
+
+        private PlayableDirector cachedDirector;
+
+        public void StartAction()
+        {
+            Start();
+        }
+
+        public void StopAction()
+        {
+            Stop();
+        }
+
+        protected override void OnStart()
+        {
+            var director = ResolveDirector();
+
+            if (restartFromBeginning)
+            {
+                director.time = 0d;
+            }
+
+            director.Play();
+        }
+
+        protected override void OnStop()
+        {
+            if (!stopOnActionStop)
+            {
+                return;
+            }
+
+            var director = cachedDirector ?? ResolveDirector();
+            director.Stop();
+        }
+
+        private PlayableDirector ResolveDirector()
+        {
+            if (targetDirectorObject == null)
+            {
+                throw new InvalidOperationException("PlayableDirector GameObject provider has not been assigned.");
+            }
+
+            var gameObject = targetDirectorObject.V;
+            if (gameObject == null)
+            {
+                throw new InvalidOperationException("The PlayableDirector GameObject provider returned a null instance.");
+            }
+
+            cachedDirector = gameObject.GetComponent<PlayableDirector>();
+            if (cachedDirector == null)
+            {
+                throw new InvalidOperationException($"PlayableDirector component was not found on '{gameObject.name}'.");
+            }
+
+            return cachedDirector;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayableDirectorStartAction to launch timeline directors from sequences
- add an AnimatorStateAction to play and optionally restore animator states

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0d33091b483208af75ea5223f10a3