### PR TITLE
Convert lerp actions to configurable value providers

### DIFF
--- a/Scripts/Values/Primitives/BoolValue.cs
+++ b/Scripts/Values/Primitives/BoolValue.cs
@@ -9,8 +9,17 @@ namespace Jungle.Values.Primitives
     [Serializable]
     public class BoolValue : LocalValue<bool>, IBoolValue
     {
+        public BoolValue()
+        {
+        }
+
+        public BoolValue(bool value)
+            : base(value)
+        {
+        }
+
         public override bool HasMultipleValues => false;
-        
+
     }
 
 }

--- a/Scripts/Values/Primitives/FloatValue.cs
+++ b/Scripts/Values/Primitives/FloatValue.cs
@@ -9,7 +9,16 @@ namespace Jungle.Values.Primitives
     [Serializable]
     public class FloatValue : LocalValue<float>, IFloatValue
     {
+        public FloatValue()
+        {
+        }
+
+        public FloatValue(float value)
+            : base(value)
+        {
+        }
+
         public override bool HasMultipleValues => false;
-        
+
     }
 }

--- a/Scripts/Values/Primitives/StringValue.cs
+++ b/Scripts/Values/Primitives/StringValue.cs
@@ -9,7 +9,16 @@ namespace Jungle.Values.Primitives
     [Serializable]
     public class StringValue : LocalValue<string>, IStringValue
     {
+        public StringValue()
+        {
+        }
+
+        public StringValue(string value)
+            : base(value)
+        {
+        }
+
         public override bool HasMultipleValues => false;
-        
+
     }
 }

--- a/Scripts/Values/UnityTypes/AnimationCurveValue.cs
+++ b/Scripts/Values/UnityTypes/AnimationCurveValue.cs
@@ -10,7 +10,16 @@ namespace Jungle.Values.UnityTypes
     [Serializable]
     public class AnimationCurveValue : LocalValue<AnimationCurve>, IAnimationCurveValue
     {
+        public AnimationCurveValue()
+        {
+        }
+
+        public AnimationCurveValue(AnimationCurve value)
+            : base(value)
+        {
+        }
+
         public override bool HasMultipleValues => false;
-        
+
     }
 }

--- a/Scripts/Values/UnityTypes/Vector3Value.cs
+++ b/Scripts/Values/UnityTypes/Vector3Value.cs
@@ -10,6 +10,15 @@ namespace Jungle.Values.UnityTypes
     [Serializable]
     public class Vector3Value : LocalValue<Vector3>, IVector3Value
     {
+        public Vector3Value()
+        {
+        }
+
+        public Vector3Value(Vector3 value)
+            : base(value)
+        {
+        }
+
         public override bool HasMultipleValues => false;
     }
 }


### PR DESCRIPTION
## Summary
- replace serialized primitives in transform and animator lerp actions with IValue-backed providers so gameplay data can be driven dynamically
- add convenience constructors to primitive and Unity value implementations for easier default initialization
- adjust lerp routines to consume resolved values and gracefully handle zero-duration transitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0d36cfb208320a6bad6429bfc42ed